### PR TITLE
Updates to NZ Film On Demand 

### DIFF
--- a/nzfilm.py
+++ b/nzfilm.py
@@ -2,84 +2,74 @@ import json
 import util
 import urllib
 
-DATA_URL = 'https://ondemand.nzfilm.co.nz/services/meta/v3/featured/show/home_page'
-DETAILS_TEMPLATE = "https://ondemand.nzfilm.co.nz/services/meta/v2/{0}/{1}/show_multiple"
-PRICE_TEMPLATE = "https://ondemand.nzfilm.co.nz/services/pricing/v2/prices/show_multiple?items=/film/{0}&location=nz"
-IMAGE_TEMPLATE = "https://s3-ap-southeast-2.amazonaws.com/s72-client-3-assets/production/posters-and-backdrops/282x422/film-{0}.jpg"
-URI_TEMPLATE = "https://ondemand.nzfilm.co.nz/#!/browse/{0}/{1}/{2}"
+# SHIFT API Documentation
+# http://indiereign.github.io/shift72-docs/
 
+DATA_URL = 'https://ondemand.nzfilm.co.nz/services/meta/v3/featured/show/home_page'
+FILM_DETAILS_TEMPLATE = "https://ondemand.nzfilm.co.nz/services/meta/v2{0}/show_multiple"
+PRICE_TEMPLATE = "https://ondemand.nzfilm.co.nz/services/pricing/v2/prices/show_multiple?items={0}&location=nz"
+URI_TEMPLATE = "https://ondemand.nzfilm.co.nz/#!/browse{0}/{1}"
 TV_SEASON_TEMPLATE = "https://ondemand.nzfilm.co.nz/services/meta/v2/tv/season/show_multiple?items={0}"
 
-def get_movie(id):
+def get_movie(slug):
+	# find movie
+	data = util.get_url_json(FILM_DETAILS_TEMPLATE.format(slug))[0]
+	price_data = util.get_url_json(PRICE_TEMPLATE.format(slug))
 
-	# find seasons
-	data = util.get_url_json(DETAILS_TEMPLATE.format("film", id))[0]
-	price_data = util.get_url_json(PRICE_TEMPLATE.format(id))
-	
 	show = {}
 	show["title"] = data["title"]
-	show["type"] = "movie"	
-	show["image"] = IMAGE_TEMPLATE.format(id)
+	show["type"] = "movie"
+	show["image"] = data["image_urls"]["portrait"]
 	show["year"] = data["release_date"][:4]
-	
-	# lowest price
-	if "sd" in price_data["prices"][0]["rent"]:
-		price = price_data["prices"][0]["rent"]["sd"]
-	else:
-		price = price_data["prices"][0]["rent"]["hd"]
-	
-	# every show has an episode even movies
-	show["episodes"] = [{"show" : data["title"], "uri" : URI_TEMPLATE.format("film", id, urllib.parse.quote_plus(data["title"])), "s" : 0, "e" : 0, "price" : price}]
-	return show
-	
-def get_tv(path):
 
-	# find seasons
-	id = path.split('/')[2]
-	data = util.get_url_json(DETAILS_TEMPLATE.format("tv", id))[id]
-	season_data = util.get_url_json(TV_SEASON_TEMPLATE.format(path))["seasons"][0]
-	
-	#https://ondemand.nzfilm.co.nz/services/pricing/v2/prices/show_multiple?items=/tv/6/season/1&location=nz
-	
-	show = {}
-	show["title"] = data["title"]
-	show["type"] = "tv"	
-	#show["image"] = IMAGE_TEMPLATE.format(id)
-	show["year"] = data["published_date"][:4]
-	
 	# lowest price
-	#if "sd" in price_data["prices"][0]["rent"]:
-	#	price = price_data["prices"][0]["rent"]["sd"]
-	#else:
-	#	price = price_data["prices"][0]["rent"]["hd"]
+	price = price_data["prices"][0]["rent"]["hd"]
+
+	# every show has an episode even movies
+	show["episodes"] = [{"show" : data["title"], "uri" : URI_TEMPLATE.format(slug, urllib.parse.quote_plus(data["title"])), "s" : 0, "e" : 0, "price" : price}]
+	return show
+
+def get_tv(slug):
+	# find seasons
+	data = util.get_url_json(TV_SEASON_TEMPLATE.format(slug))["seasons"][0]
+	price_data = util.get_url_json(PRICE_TEMPLATE.format(slug))
+
+	show = {}
+	show["title"] = data["show_info"]["title"]
+	show["type"] = "tv"
+	show["image"] = data["image_urls"]["portrait"]
+	show["year"] = data["show_info"]["release_date"][:4]
+
+	# Price is per season. No prices per episode
+	# lowest price
+	price = price_data["prices"][0]["rent"]["hd"]
+	print ("TV Price: " + price)
 
 	show["episodes"] = []
-	for e in season_data["episodes"]:
+	for e in data["episodes"]:
 			episode = {}
-			print("s" + str(season_data["season_num"]) + "e" + str(e["episode_number"]) + " - " + e["title"])
 			episode["title"] = e["title"]
-			episode["uri"] = URI_TEMPLATE.format("tv", id, "season/{0}/{1}".format(season_data["season_num"], urllib.parse.quote_plus(data["title"])))
-			episode["s"] = season_data["season_num"]
+			episode["uri"] = URI_TEMPLATE.format(slug, urllib.parse.quote_plus(data["show_info"]["title"]))
+			episode["s"] = data["season_num"]
 			episode["e"] = e["episode_number"]
-			episode["year"] = e["air_date"][:4]
 			show["episodes"].append(episode)
-	
-	return show	
+
+	return show
 
 def get_listings():
-	shows = []	
+	shows = []
 	data = util.get_url_json(DATA_URL)
 
 	all = []
 	for feature in data["features"]:
 		if "/film/" in feature["item"]:
-			shows.append(get_movie(feature["item"].replace("/film/", "")))
+			shows.append(get_movie(feature["item"]))
 		else:
 			shows.append(get_tv(feature["item"]))
 
 	return shows
 
-if __name__ == "__main__":	
+if __name__ == "__main__":
 	# Test works
 	f = open("nzfilm.js", "w")
 	f.write(json.dumps(get_listings()))


### PR DESCRIPTION
TV no longer errors. Forced the price to the HD rent price as SD prices are deprecated and the prices were not showing. Updated the image path to use the value returned by the API.

One question: NZ Film On Demand TV prices are by season and not episode. Can the price be at the season level or does it need to be at the episode level? The price for TV is currently being printed but it's not being saved.
